### PR TITLE
Fix Wayland backend

### DIFF
--- a/sdl2webgpu.c
+++ b/sdl2webgpu.c
@@ -95,7 +95,7 @@ WGPUSurface SDL_GetWGPUSurface(WGPUInstance instance, SDL_Window* window) {
 #elif defined(SDL_VIDEO_DRIVER_WAYLAND)
     {
         struct wl_display* wayland_display = windowWMInfo.info.wl.display;
-        struct wl_surface* wayland_surface = windowWMInfo.info.wl.display;
+        struct wl_surface* wayland_surface = windowWMInfo.info.wl.surface;
         return wgpuInstanceCreateSurface(
             instance,
             &(WGPUSurfaceDescriptor){


### PR DESCRIPTION
There seems to have been a typo before, where the wl_display was passed as both the display and surface.